### PR TITLE
burnBCH example complete, README updated

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -36,10 +36,11 @@ You can run each example script by entering its directory and executing `npm sta
 These example apps roughly follow the
 [third Wormhole tutorial](https://developer.bitcoin.com/tutorials/wormhole-3-tokens.html)
 
-- [burn-bch](burn-bch) **NOT WORKING**
+- [burn-bch](burn-bch)
   Burn 1 BCH to generate 100 WHC tokens. These WHC tokens
-  are needed for creating your own tokens. You'll need to wait for 1 confirmation
-  before seeing the WHC tokens in your account.
+  are needed for creating your own tokens. Before seeing the WHC tokens appear
+  in the `check-balance` example, you'll have to wait 4 confirmations on testnet
+  and 1000 confirmations (7 days) on mainnet.
 
 - [lookup-token](data-retrieval/lookup-token) Lookup token information based on
   the `primaryid` value assigned to it.
@@ -73,7 +74,7 @@ be revoked.
 - [change-managed-token-issuer](change-managed-token-issuer) Change the address
   capable of issuing new tokens, the 'Token Manager'.
 
-- [revoke-managed-tokens](revoke-managed-tokens) Revoke existing tokens. 
+- [revoke-managed-tokens](revoke-managed-tokens) Revoke existing tokens.
 
 
 ### Crowd Sale

--- a/examples/burn-bch/burn-bch.js
+++ b/examples/burn-bch/burn-bch.js
@@ -126,9 +126,8 @@ async function burnBch() {
 
     // sendRawTransaction to running BCH node
     // const broadcast = await Wormhole.RawTransactions.sendRawTransaction(txHex)
-
-    console.log(`You can monitor the below transaction ID on a block explorer.`)
-    console.log(`Transaction ID: ${broadcast}`)
+    //console.log(`You can monitor the below transaction ID on a block explorer.`)
+    //console.log(`Transaction ID: ${broadcast}`)
   } catch (err) {
     console.error(err)
   }

--- a/examples/burn-bch/burn-bch.js
+++ b/examples/burn-bch/burn-bch.js
@@ -32,15 +32,6 @@ try {
 
 async function burnBch() {
   try {
-    // Exit if the user does not have 1.0 BCH to burn.
-    //const bchBalance = await getBCHBalance(walletInfo.cashAddress, false)
-    if (bchBalance < 1.0) {
-      console.log(
-        `Wallet has a balance of ${bchBalance} which is less than the 1 BCH requirement to burn. Exiting.`
-      )
-      process.exit(0)
-    }
-
     const mnemonic = walletInfo.mnemonic
 
     // root seed buffer
@@ -52,7 +43,7 @@ async function burnBch() {
     else var masterHDNode = Wormhole.HDNode.fromSeed(rootSeed, "testnet") // Testnet
 
     // HDNode of BIP44 account
-    const account = Wormhole.HDNode.derivePath(masterHDNode, "m/44'/145'/1'")
+    const account = Wormhole.HDNode.derivePath(masterHDNode, "m/44'/145'/0'")
 
     const change = Wormhole.HDNode.derivePath(account, "0/0")
 
@@ -68,6 +59,7 @@ async function burnBch() {
       process.exit(0)
     }
 
+    // Get the burnBCH payload.
     const burnBCH = await Wormhole.PayloadCreation.burnBCH()
 
     // Get a utxo to use for this transaction.
@@ -85,13 +77,20 @@ async function burnBch() {
     // amount of BCH set to a minimal amount.
     const burnAddr = "bchtest:qqqqqqqqqqqqqqqqqqqqqqqqqqqqqdmwgvnjkt8whc"
     //const ref = await Wormhole.RawTransactions.reference(opReturn, cashAddress)
-    const ref = await Wormhole.RawTransactions.reference(opReturn, burnAddr)
+    // Creates the
+    //const ref = await Wormhole.RawTransactions.reference(opReturn, burnAddr)
 
-    const minerFee = 0.000005
+    const minerFee = 0.00001
+
+    // amount to send back to the sending address. It's the original amount - 1 sat/byte for tx size
+    const remainder = bchBalance - 1.0 - minerFee
+
+    //opReturn.addOutput(cashAddress, remainder)
 
     // Generate a change output.
     const changeHex = await Wormhole.RawTransactions.change(
-      ref, // Raw transaction we're working with.
+      //ref, // Raw transaction we're working with.
+      opReturn,
       [utxo], // Previous utxo
       burnAddr, // Destination address.
       //cashAddress,

--- a/examples/burn-bch/burn-bch.js
+++ b/examples/burn-bch/burn-bch.js
@@ -19,7 +19,6 @@ if (NETWORK === `mainnet`)
   var Wormhole = new WH({ restURL: `https://rest.bitcoin.com/v1/` })
 else var Wormhole = new WH({ restURL: `https://trest.bitcoin.com/v1/` })
 
-
 // Open the wallet generated with create-wallet.
 let walletInfo
 try {
@@ -34,7 +33,7 @@ try {
 async function burnBch() {
   try {
     // Exit if the user does not have 1.0 BCH to burn.
-    const bchBalance = await getBCHBalance(walletInfo.cashAddress, false)
+    //const bchBalance = await getBCHBalance(walletInfo.cashAddress, false)
     if (bchBalance < 1.0) {
       console.log(
         `Wallet has a balance of ${bchBalance} which is less than the 1 BCH requirement to burn. Exiting.`

--- a/examples/burn-bch/burn-bch.js
+++ b/examples/burn-bch/burn-bch.js
@@ -2,13 +2,6 @@
   Burn 1 BCH to generate 100 WHC used for creating new tokens.
 */
 
-// Used for debugging.
-const util = require("util")
-util.inspect.defaultOptions = {
-  showHidden: true,
-  colors: true
-}
-
 // Set NETWORK to either testnet or mainnet
 const NETWORK = `testnet`
 
@@ -45,9 +38,10 @@ async function burnBch() {
     // HDNode of BIP44 account
     const account = Wormhole.HDNode.derivePath(masterHDNode, "m/44'/145'/0'")
 
+    // Generate the first change address.
     const change = Wormhole.HDNode.derivePath(account, "0/0")
 
-    // get the cash address
+    // get the cash address from the change address.
     const cashAddress = Wormhole.HDNode.toCashAddress(change)
 
     // Exit if the user does not have 1.0 BCH to burn.
@@ -59,50 +53,45 @@ async function burnBch() {
       process.exit(0)
     }
 
-    // Get the burnBCH payload.
+    // Get the Wormohle burnBCH payload.
     const burnBCH = await Wormhole.PayloadCreation.burnBCH()
 
     // Get a utxo to use for this transaction.
     const u = await Wormhole.Address.utxo([cashAddress])
     const utxo = findBiggestUtxo(u[0])
 
-    //
-    //
-    //
-
-    // instance of transaction builder
+    // Instatiate the transaction builder
     if (NETWORK === `mainnet`)
       var transactionBuilder = new Wormhole.TransactionBuilder()
     else var transactionBuilder = new Wormhole.TransactionBuilder("testnet")
 
-    console.log(`utxo: ${util.inspect(utxo)}`)
+    // Create the input part of the transaction.
     const vout = utxo.vout
     const txid = utxo.txid
     transactionBuilder.addInput(txid, vout)
 
-    utxo.value = utxo.amount
-    //const rawTx = await Wormhole.RawTransactions.create([utxo], {})
-
-    const minerFee = 1000
-
-    // amount to send back to the sending address. It's the original amount - 1 sat/byte for tx size
-    const remainder = Math.floor(bchBalance * 100000000 - 100000000 - minerFee)
-    console.log(`remainder: ${remainder}`)
-
+    // Constant values to be used in creating the output of the TX.
+    const satoshiBalance = utxo.satoshis
+    const satoshisToBurn = 100000000
+    const minerFee = 1000 // This could be more refined than a hard value.
     const burnAddr = "bchtest:qqqqqqqqqqqqqqqqqqqqqqqqqqqqqdmwgvnjkt8whc"
 
+    // Remainder amount to send back to the sending address.
+    const remainder = satoshiBalance - satoshisToBurn - minerFee
+    console.log(
+      `remainder: ${remainder} satoshis - will be sent back to orginating address.`
+    )
+
+    // Generate the op_return code for Wormhole.
     const opReturn = Wormhole.Script.encode([
       Wormhole.Script.opcodes.OP_RETURN,
       burnBCH
     ])
 
-    // add output w/ address and amount to send
-    transactionBuilder.addOutput(burnAddr, 100000000)
-    transactionBuilder.addOutput(opReturn, 0) // Op_return
-    transactionBuilder.addOutput(
-      Wormhole.Address.toLegacyAddress(cashAddress),
-      remainder
-    )
+    // add outputs w/ address and amount to send
+    transactionBuilder.addOutput(burnAddr, satoshisToBurn)
+    transactionBuilder.addOutput(opReturn, 0) // Op_return for WH
+    transactionBuilder.addOutput(cashAddress, remainder)
 
     // Generate a keypair from the change address.
     const keyPair = Wormhole.HDNode.toKeyPair(change)
@@ -114,90 +103,17 @@ async function burnBch() {
       keyPair,
       redeemScript,
       transactionBuilder.hashTypes.SIGHASH_ALL,
-      Math.floor(bchBalance * 100000000)
+      satoshiBalance
     )
 
     // build tx
     const tx = transactionBuilder.build()
     const hex = tx.toHex()
-    console.log(hex)
+    //console.log(hex)
 
-    //
-    //
-    //
-
-    /*
-
-    // Create a rawTx using the largest utxo in the wallet.
-    //utxo.value = utxo.amount
-    //const rawTx = await Wormhole.RawTransactions.create([utxo], {})
-
-    // Add the token information as an op-return code to the tx.
-    const opReturn = await Wormhole.RawTransactions.opReturn(rawTx, burnBCH)
-    console.log(`opReturn: ${util.inspect(opReturn)}`)
-
-    // Set the destination/recieving address for the tokens, with the actual
-    // amount of BCH set to a minimal amount.
-
-    //const ref = await Wormhole.RawTransactions.reference(opReturn, cashAddress)
-    // Creates the
-    //const ref = await Wormhole.RawTransactions.reference(opReturn, burnAddr)
-
-
-    //opReturn.addOutput(cashAddress, remainder)
-
-    // Generate a change output.
-    const changeHex = await Wormhole.RawTransactions.change(
-      //ref, // Raw transaction we're working with.
-      opReturn,
-      [utxo], // Previous utxo
-      burnAddr, // Destination address.
-      //cashAddress,
-      minerFee // Miner fee.
-    )
-
-    */
-    /*
-    const tx = Wormhole.Transaction.fromHex(ref)
-    tx.outs.unshift({
-      value: 199990000,
-      script: Buffer.from(
-        "76a9140000000000000000000000000000000000376e4388ac",
-        "hex"
-      )
-    })
-    const buf = Wormhole.Script.pubKey.output.encode(
-      Buffer.from("bchtest:", "hex")
-    )
-
-    console.log(tx.outs)
-    const tb = Wormhole.Transaction.fromTransaction(tx)
-    // let ca = "mfWxJ45yp2SFn7UciZyNpvDKu6S3TYMHMR";
-    // console.log(tb);
-    // tb.addOutput('qqqqqqqqqqqqqqqqqqqqqqqqqqqqqdmwgvnjkt8whc', Wormhole.BitcoinCash.toSatoshi(1));
-    */
-    /*
-    //const tx = Wormhole.Transaction.fromHex(changeHex)
-    const tb = Wormhole.Transaction.fromTransaction(tx)
-
-    // amount to send back to the sending address. It's the original amount - 1 sat/byte for tx size
-    //const remainder = bchBalance - 1.0 - minerFee
-    //tb.addOutput(walletInfo.cashAddress, remainder)
-
-    // Finalize and sign transaction.
-    const keyPair = Wormhole.HDNode.toKeyPair(change)
-    let redeemScript
-    tb.sign(0, keyPair, redeemScript, 0x01, utxo.satoshis)
-    const builtTx = tb.build()
-    const txHex = builtTx.toHex()
-    console.log(txHex)
-    */
-
-    // sendRawTransaction to running BCH node
-
-    // const broadcast = await Wormhole.RawTransactions.sendRawTransaction(txHex)
-    //console.log(`You can monitor the below transaction ID on a block explorer.`)
-    //console.log(`Transaction ID: ${broadcast}`)
+    const broadcast = await Wormhole.RawTransactions.sendRawTransaction(hex)
+    console.log(`You can monitor the below transaction ID on a block explorer.`)
+    console.log(`Transaction ID: ${broadcast}`)
   } catch (err) {
     console.error(err)
   }

--- a/examples/burn-bch/burn-bch.js
+++ b/examples/burn-bch/burn-bch.js
@@ -47,9 +47,9 @@ async function burnBch() {
     const rootSeed = Wormhole.Mnemonic.toSeed(mnemonic)
 
     // master HDNode
-    if (NETWORK === `mainnet`)
-      var masterHDNode = Wormhole.HDNode.fromSeed(rootSeed)
-    else var masterHDNode = Wormhole.HDNode.fromSeed(rootSeed, "testnet") // Testnet
+    let masterHDNode
+    if (NETWORK === `mainnet`) masterHDNode = Wormhole.HDNode.fromSeed(rootSeed)
+    else masterHDNode = Wormhole.HDNode.fromSeed(rootSeed, "testnet") // Testnet
 
     // HDNode of BIP44 account
     const account = Wormhole.HDNode.derivePath(masterHDNode, "m/44'/145'/0'")
@@ -57,7 +57,7 @@ async function burnBch() {
     const change = Wormhole.HDNode.derivePath(account, "0/0")
 
     // get the cash address
-    const cashAddress = walletInfo.cashAddress
+    const cashAddress = Wormhole.HDNode.toCashAddress(change)
 
     const burnBCH = await Wormhole.PayloadCreation.burnBCH()
 
@@ -75,7 +75,7 @@ async function burnBch() {
     // Set the destination/recieving address for the tokens, with the actual
     // amount of BCH set to a minimal amount.
     const burnAddr = "bchtest:qqqqqqqqqqqqqqqqqqqqqqqqqqqqqdmwgvnjkt8whc"
-    const ref = await Wormhole.RawTransactions.reference(opReturn, burnAddr)
+    const ref = await Wormhole.RawTransactions.reference(opReturn, cashAddress)
     //const ref = await Wormhole.RawTransactions.reference(opReturn, cashAddress)
 
     const minerFee = 0.000005
@@ -122,10 +122,10 @@ async function burnBch() {
     tb.sign(0, keyPair, redeemScript, 0x01, utxo.satoshis)
     const builtTx = tb.build()
     const txHex = builtTx.toHex()
-    //console.log(txHex)
+    console.log(txHex)
 
     // sendRawTransaction to running BCH node
-    const broadcast = await Wormhole.RawTransactions.sendRawTransaction(txHex)
+    // const broadcast = await Wormhole.RawTransactions.sendRawTransaction(txHex)
 
     console.log(`You can monitor the below transaction ID on a block explorer.`)
     console.log(`Transaction ID: ${broadcast}`)

--- a/examples/check-balance/check-balance.js
+++ b/examples/check-balance/check-balance.js
@@ -6,7 +6,7 @@
 // Set NETWORK to either testnet or mainnet
 const NETWORK = `testnet`
 
-const WH = require("wormhole-sdk/lib/Wormhole").default
+const WH = require("../../lib/Wormhole").default
 
 // Instantiate Wormhole based on the network.
 if (NETWORK === `mainnet`)

--- a/examples/check-balance/check-balance.js
+++ b/examples/check-balance/check-balance.js
@@ -9,10 +9,9 @@ const NETWORK = `testnet`
 const WH = require("../../lib/Wormhole").default
 
 // Instantiate Wormhole based on the network.
-let Wormhole
 if (NETWORK === `mainnet`)
-  Wormhole = new WH({ restURL: `https://rest.bitcoin.com/v1/` })
-else Wormhole = new WH({ restURL: `https://trest.bitcoin.com/v1/` })
+  var Wormhole = new WH({ restURL: `https://rest.bitcoin.com/v1/` })
+else var Wormhole = new WH({ restURL: `https://trest.bitcoin.com/v1/` })
 
 // Open the wallet generated with create-wallet.
 let walletInfo
@@ -37,7 +36,7 @@ async function getBalance() {
     else var masterHDNode = Wormhole.HDNode.fromSeed(rootSeed, "testnet") // Testnet
 
     // HDNode of BIP44 account
-    const account = Wormhole.HDNode.derivePath(masterHDNode, "m/44'/145'/1'")
+    const account = Wormhole.HDNode.derivePath(masterHDNode, "m/44'/145'/0'")
 
     const change = Wormhole.HDNode.derivePath(account, "0/0")
 

--- a/examples/create-wallet/create-wallet.js
+++ b/examples/create-wallet/create-wallet.js
@@ -6,7 +6,7 @@
 // Set NETWORK to either testnet or mainnet
 const NETWORK = `testnet`
 
-const WH = require("wormhole-sdk/lib/Wormhole").default
+const WH = require("../../lib/Wormhole").default
 
 // Instantiate Wormhole based on the network.
 if (NETWORK === `mainnet`)

--- a/examples/send-bch/send-bch.js
+++ b/examples/send-bch/send-bch.js
@@ -6,12 +6,12 @@
 const NETWORK = `testnet`
 
 // Replace the address below with the address you want to send the BCH to.
-const RECV_ADDR = `bchtest:qq7cfllv3r32rkvd9qfaejwz78spfxp6qyflftn6x8`
+const RECV_ADDR = `bchtest:qzjtnzcvzxx7s0na88yrg3zl28wwvfp97538sgrrmr`
 
 // The amount of BCH to send, in satoshis. 1 satoshi = 0.00000001 BCH
-const AMOUNT_TO_SEND = 100100000
+const AMOUNT_TO_SEND = 10000
 
-const WH = require("wormhole-sdk/lib/Wormhole").default
+const WH = require("../../lib/Wormhole").default
 
 // Instantiate Wormhole based on the network.
 let Wormhole
@@ -36,8 +36,12 @@ const change = changeAddrFromMnemonic(SEND_MNEMONIC)
 const SEND_ADDR = Wormhole.HDNode.toCashAddress(change)
 
 async function sendBch() {
+  const SEND_ADDR_LEGACY = Wormhole.Address.toLegacyAddress(SEND_ADDR)
+  const RECV_ADDR_LEGACY = Wormhole.Address.toLegacyAddress(RECV_ADDR)
+
   const balance = await getBCHBalance(SEND_ADDR, false)
-  console.log(`balance: ${JSON.stringify(balance, null, 2)}`)
+  console.log(`Send Address: ${SEND_ADDR}`)
+  console.log(`Sender Legacy Address: ${SEND_ADDR_LEGACY}`)
   console.log(`Balance of sending address ${SEND_ADDR} is ${balance} BCH.`)
 
   if (balance <= 0.0) {
@@ -45,21 +49,17 @@ async function sendBch() {
     process.exit(0)
   }
 
-  const SEND_ADDR_LEGACY = Wormhole.Address.toLegacyAddress(SEND_ADDR)
-  const RECV_ADDR_LEGACY = Wormhole.Address.toLegacyAddress(RECV_ADDR)
-  console.log(`Sender Legacy Address: ${SEND_ADDR_LEGACY}`)
-  console.log(`Receiver Legacy Address: ${RECV_ADDR_LEGACY}`)
-
   const balance2 = await getBCHBalance(RECV_ADDR, false)
-  console.log(`Balance of recieving address ${RECV_ADDR} is ${balance2} BCH.`)
+  console.log(`\nReceiver Address: ${RECV_ADDR}`)
+  console.log(`Receiver Legacy Address: ${RECV_ADDR_LEGACY}`)
+  console.log(`Balance of recieving address ${RECV_ADDR} is ${balance2} BCH.\n`)
 
   const utxo = await Wormhole.Address.utxo([SEND_ADDR])
 
   // instance of transaction builder
-  let transactionBuilder
   if (NETWORK === `mainnet`)
-    transactionBuilder = new Wormhole.TransactionBuilder()
-  else transactionBuilder = new Wormhole.TransactionBuilder("testnet")
+    var transactionBuilder = new Wormhole.TransactionBuilder()
+  else var transactionBuilder = new Wormhole.TransactionBuilder("testnet")
 
   const satoshisToSend = AMOUNT_TO_SEND
   const originalAmount = utxo[0][0].satoshis
@@ -77,7 +77,7 @@ async function sendBch() {
   console.log(`byteCount: ${byteCount}`)
   const satoshisPerByte = 1.1
   const txFee = Math.floor(satoshisPerByte * byteCount)
-  console.log(`txFee: ${txFee}`)
+  console.log(`txFee: ${txFee} satoshis\n`)
 
   // amount to send back to the sending address. It's the original amount - 1 sat/byte for tx size
   const remainder = originalAmount - satoshisToSend - txFee


### PR DESCRIPTION
The burnBCH example now works and only burns 1.0 BCH. It will send the remainder back to the originating address, just like the send-bch example does.