### PR TITLE
Fixing burnBCH (Really! I mean it.)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -42,6 +42,11 @@ These example apps roughly follow the
   in the `check-balance` example, you'll have to wait 4 confirmations on testnet
   and 1000 confirmations (7 days) on mainnet.
 
+  This is just an example, *not intended for real burning!*. One side effect of
+  this early example is that it will consume all the BCH in a UTXO. *Be sure
+  to use a new wallet with a 1.00001000 tBCH (1 BCH + TX fee). Anything in
+  addition to this will be burned.*
+
 - [lookup-token](data-retrieval/lookup-token) Lookup token information based on
   the `primaryid` value assigned to it.
 

--- a/examples/burn-bch/burn-bch.js
+++ b/examples/burn-bch/burn-bch.js
@@ -2,6 +2,13 @@
   Burn 1 BCH to generate 100 WHC used for creating new tokens.
 */
 
+// Used for debugging.
+const util = require("util")
+util.inspect.defaultOptions = {
+  showHidden: true,
+  colors: true
+}
+
 // Set NETWORK to either testnet or mainnet
 const NETWORK = `testnet`
 
@@ -38,15 +45,13 @@ async function burnBch() {
     // HDNode of BIP44 account
     const account = Wormhole.HDNode.derivePath(masterHDNode, "m/44'/145'/0'")
 
-    // Generate the first change address.
     const change = Wormhole.HDNode.derivePath(account, "0/0")
 
-    // get the cash address from the change address.
+    // get the cash address
     const cashAddress = Wormhole.HDNode.toCashAddress(change)
 
     // Exit if the user does not have 1.0 BCH to burn.
     const bchBalance = await getBCHBalance(cashAddress, false)
-    console.log(`bchBalance: ${bchBalance}`)
     if (bchBalance < 1.0) {
       console.log(
         `Wallet has a balance of ${bchBalance} which is less than the 1 BCH requirement to burn. Exiting.`
@@ -54,69 +59,82 @@ async function burnBch() {
       process.exit(0)
     }
 
+    // Get the burnBCH payload.
+    const burnBCH = await Wormhole.PayloadCreation.burnBCH()
+
     // Get a utxo to use for this transaction.
     const u = await Wormhole.Address.utxo([cashAddress])
     const utxo = findBiggestUtxo(u[0])
+    console.log(`utxo: ${util.inspect(utxo)}`)
 
-    // Instatiate the transaction builder
-    if (NETWORK === `mainnet`)
-      var transactionBuilder = new Wormhole.TransactionBuilder()
-    else var transactionBuilder = new Wormhole.TransactionBuilder("testnet")
+    // Create a rawTx using the largest utxo in the wallet.
+    utxo.value = utxo.amount
+    const rawTx = await Wormhole.RawTransactions.create([utxo], {})
 
-    // Create the input part of the transaction.
-    const vout = utxo.vout
-    const txid = utxo.txid
-    transactionBuilder.addInput(txid, vout)
+    // Add the token information as an op-return code to the tx.
+    const opReturn = await Wormhole.RawTransactions.opReturn(rawTx, burnBCH)
 
-    // Constant values to be used in creating the output of the TX.
-    const satoshiBalance = utxo.satoshis
-    const satoshisToBurn = 100000000
-    const minerFee = 1000 // This could be more refined than a hard value.
+    // Set the destination/recieving address for the tokens, with the actual
+    // amount of BCH set to a minimal amount.
     const burnAddr = "bchtest:qqqqqqqqqqqqqqqqqqqqqqqqqqqqqdmwgvnjkt8whc"
+    //const ref = await Wormhole.RawTransactions.reference(opReturn, cashAddress)
+    // Creates the
+    //const ref = await Wormhole.RawTransactions.reference(opReturn, burnAddr)
 
-    // Remainder amount to send back to the sending address.
-    const remainder = satoshiBalance - satoshisToBurn - minerFee
-    console.log(
-      `remainder: ${remainder} satoshis - will be sent back to orginating address.`
+    const minerFee = 0.00001
+
+    // amount to send back to the sending address. It's the original amount - 1 sat/byte for tx size
+    const remainder = bchBalance - 1.0 - minerFee
+
+    //opReturn.addOutput(cashAddress, remainder)
+
+    // Generate a change output.
+    const changeHex = await Wormhole.RawTransactions.change(
+      //ref, // Raw transaction we're working with.
+      opReturn,
+      [utxo], // Previous utxo
+      burnAddr, // Destination address.
+      //cashAddress,
+      minerFee // Miner fee.
     )
 
-    // add outputs w/ address and amount to send
-    transactionBuilder.addOutput(burnAddr, satoshisToBurn)
-    transactionBuilder.addOutput(cashAddress, remainder)
+    /*
+    const tx = Wormhole.Transaction.fromHex(ref)
+    tx.outs.unshift({
+      value: 199990000,
+      script: Buffer.from(
+        "76a9140000000000000000000000000000000000376e4388ac",
+        "hex"
+      )
+    })
+    const buf = Wormhole.Script.pubKey.output.encode(
+      Buffer.from("bchtest:", "hex")
+    )
+    console.log(tx.outs)
+    const tb = Wormhole.Transaction.fromTransaction(tx)
+    // let ca = "mfWxJ45yp2SFn7UciZyNpvDKu6S3TYMHMR";
+    // console.log(tb);
+    // tb.addOutput('qqqqqqqqqqqqqqqqqqqqqqqqqqqqqdmwgvnjkt8whc', Wormhole.BitcoinCash.toSatoshi(1));
+    */
 
-    // Generate a keypair from the change address.
+    const tx = Wormhole.Transaction.fromHex(changeHex)
+    const tb = Wormhole.Transaction.fromTransaction(tx)
+
+    // amount to send back to the sending address. It's the original amount - 1 sat/byte for tx size
+    //const remainder = bchBalance - 1.0 - minerFee
+    //tb.addOutput(walletInfo.cashAddress, remainder)
+
+    // Finalize and sign transaction.
     const keyPair = Wormhole.HDNode.toKeyPair(change)
-
-    // Sign the transaction with the HD node.
     let redeemScript
-    transactionBuilder.sign(
-      0,
-      keyPair,
-      redeemScript,
-      transactionBuilder.hashTypes.SIGHASH_ALL,
-      satoshiBalance
-    )
+    tb.sign(0, keyPair, redeemScript, 0x01, utxo.satoshis)
+    const builtTx = tb.build()
+    const txHex = builtTx.toHex()
+    console.log(txHex)
 
-    // build tx
-    const tx = transactionBuilder.build()
-    const hex = tx.toHex()
+    // sendRawTransaction to running BCH node
 
-    // Get the burnBCH OP_RETURN payload.
-    const payload = await Wormhole.PayloadCreation.burnBCH()
-
-    // Modify the raw TX hex to add the WH OP_RETURN.
-    const opReturn3 = await Wormhole.RawTransactions.opReturn(hex, payload)
-
-    console.log(`
-You can review the output script for errors by replacing <tx-hex> with the TX
-hex at this URL:
-https://trest.bitcoin.com/v1/rawtransactions/decodeRawTransaction/<tx-hex>
-
-      `)
-    console.log(`TX Hex: ${opReturn3}`)
-
-    // COMMENT OUT THESE LINES TO ACTUALLY BURN A TOKEN
-    //const broadcast = await Wormhole.RawTransactions.sendRawTransaction(hex)
+    // const broadcast = await Wormhole.RawTransactions.sendRawTransaction(txHex)
     //console.log(`You can monitor the below transaction ID on a block explorer.`)
     //console.log(`Transaction ID: ${broadcast}`)
   } catch (err) {

--- a/examples/consolidate-utxos/consolidate-utxos.js
+++ b/examples/consolidate-utxos/consolidate-utxos.js
@@ -56,19 +56,16 @@ async function consolidateDust() {
     // instance of transaction builder
     const transactionBuilder = new Wormhole.TransactionBuilder("testnet")
 
+    // Combine all the utxos into the inputs of the TX.
     const u = await Wormhole.Address.utxo([cashAddress])
     const inputs = []
     let originalAmount = 0
     u[0].forEach(utxo => {
       originalAmount = originalAmount + utxo.satoshis
-      //console.log(`utxo: ${util.inspect(utxo)}`)
-      //if (utxo.satoshis === dust) {
+
       inputs.push(utxo)
 
-      // console.log(utxo.txid, utxo.vout)
-      // add input with txid and index of vout
       transactionBuilder.addInput(utxo.txid, utxo.vout)
-      //}
     })
 
     // original amount of satoshis in vin

--- a/examples/consolidate-utxos/consolidate-utxos.js
+++ b/examples/consolidate-utxos/consolidate-utxos.js
@@ -1,0 +1,127 @@
+/*
+  Consolidate dust to clean up wallet.
+*/
+
+// Inspect utility used for debugging.
+const util = require("util")
+util.inspect.defaultOptions = {
+  showHidden: true,
+  colors: true,
+  depth: 1
+}
+
+// Set NETWORK to either testnet or mainnet
+const NETWORK = `testnet`
+
+const WH = require("../../lib/Wormhole").default
+
+// Instantiate Wormhole based on the network.
+if (NETWORK === `mainnet`)
+  var Wormhole = new WH({ restURL: `https://rest.bitcoin.com/v1/` })
+else var Wormhole = new WH({ restURL: `https://trest.bitcoin.com/v1/` })
+
+// Open the wallet generated with create-wallet.
+let walletInfo
+try {
+  walletInfo = require(`../create-wallet/wallet.json`)
+} catch (err) {
+  console.log(
+    `Could not open wallet.json. Generate a wallet with create-wallet first.
+    Exiting.`
+  )
+  process.exit(0)
+}
+
+async function consolidateDust() {
+  try {
+    const mnemonic = walletInfo.mnemonic
+
+    // root seed buffer
+    const rootSeed = Wormhole.Mnemonic.toSeed(mnemonic)
+
+    // master HDNode
+    if (NETWORK === `mainnet`)
+      var masterHDNode = Wormhole.HDNode.fromSeed(rootSeed)
+    else var masterHDNode = Wormhole.HDNode.fromSeed(rootSeed, "testnet") // Testnet
+
+    // HDNode of BIP44 account
+    const account = Wormhole.HDNode.derivePath(masterHDNode, "m/44'/145'/0'")
+
+    const change = Wormhole.HDNode.derivePath(account, "0/0")
+
+    // get the cash address
+    const cashAddress = Wormhole.HDNode.toCashAddress(change)
+    // const cashAddress = walletInfo.cashAddress
+
+    // instance of transaction builder
+    const transactionBuilder = new Wormhole.TransactionBuilder("testnet")
+
+    const u = await Wormhole.Address.utxo([cashAddress])
+    const inputs = []
+    let originalAmount = 0
+    u[0].forEach(utxo => {
+      originalAmount = originalAmount + utxo.satoshis
+      //console.log(`utxo: ${util.inspect(utxo)}`)
+      //if (utxo.satoshis === dust) {
+      inputs.push(utxo)
+
+      // console.log(utxo.txid, utxo.vout)
+      // add input with txid and index of vout
+      transactionBuilder.addInput(utxo.txid, utxo.vout)
+      //}
+    })
+
+    // original amount of satoshis in vin
+    //const originalAmount = inputs.length * dust
+    console.log(`originalAmount: ${originalAmount}`)
+
+    // get byte count to calculate fee. paying 1 sat/byte
+    const byteCount = Wormhole.BitcoinCash.getByteCount(
+      { P2PKH: inputs.length },
+      { P2PKH: 1 }
+    )
+    console.log(`fee: ${byteCount}`)
+
+    // amount to send to receiver. It's the original amount - 1 sat/byte for tx size
+    const sendAmount = originalAmount - byteCount
+    console.log(`sendAmount: ${sendAmount}`)
+
+    // add output w/ address and amount to send
+    transactionBuilder.addOutput(cashAddress, sendAmount)
+
+    // keypair
+    const keyPair = Wormhole.HDNode.toKeyPair(change)
+
+    // sign w/ HDNode
+    let redeemScript
+    inputs.forEach((input, index) => {
+      //console.log(`inputs[${index}]: ${util.inspect(inputs[index])}`)
+      transactionBuilder.sign(
+        index,
+        keyPair,
+        redeemScript,
+        transactionBuilder.hashTypes.SIGHASH_ALL,
+        inputs[index].satoshis
+      )
+    })
+
+    // build tx
+    const tx = transactionBuilder.build()
+    // output rawhex
+    const hex = tx.toHex()
+
+    console.log(`
+You can review the output script for errors by replacing <tx-hex> with the TX
+hex at this URL:
+https://trest.bitcoin.com/v1/rawtransactions/decodeRawTransaction/<tx-hex>
+      `)
+    console.log(`TX Hex: ${hex}`)
+
+    // sendRawTransaction to running BCH node
+    const broadcast = await Wormhole.RawTransactions.sendRawTransaction(hex)
+    console.log(`Transaction ID: ${broadcast}`)
+  } catch (err) {
+    console.log(err)
+  }
+}
+consolidateDust()

--- a/examples/consolidate-utxos/package.json
+++ b/examples/consolidate-utxos/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "consolidate-utxos",
+  "version": "1.0.0",
+  "description": "Consolidate all UTXOs in a wallet back into a single UTXO",
+  "main": "consolidate-utxos.js",
+  "scripts": {
+    "test": "echo no tests yet",
+    "start": "node consolidate-utxos.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Bitcoin-com/wormhole-sdk.git"
+  },
+  "keywords": [
+    "wormhole-sdk",
+    "example",
+    "bch",
+    "bitcoin cash",
+    "tokens",
+    "token",
+    "wormhole",
+    "node",
+    "node.js",
+    "javascript"
+  ],
+  "author": "Chris Troutner <chris.troutner@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Bitcoin-com/wormhole-sdk/issues"
+  },
+  "homepage": "https://github.com/Bitcoin-com/wormhole-sdk#readme",
+  "dependencies": {
+    "wormhole-sdk": "^0.6.0"
+  }
+}

--- a/examples/send-bch/send-bch.js
+++ b/examples/send-bch/send-bch.js
@@ -6,10 +6,10 @@
 const NETWORK = `testnet`
 
 // Replace the address below with the address you want to send the BCH to.
-const RECV_ADDR = `bchtest:qp6hgvevf4gzz6l7pgcte3gaaud9km0l459fa23dul`
+const RECV_ADDR = ``
 
 // The amount of BCH to send, in satoshis. 1 satoshi = 0.00000001 BCH
-const AMOUNT_TO_SEND = 68270906
+const AMOUNT_TO_SEND = 50701489
 
 const WH = require("../../lib/Wormhole").default
 
@@ -56,6 +56,7 @@ async function sendBch() {
 
   const u = await Wormhole.Address.utxo([SEND_ADDR])
   const utxo = findBiggestUtxo(u[0])
+  //console.log(`utxo: ${JSON.stringify(utxo, null, 2)}`)
 
   // instance of transaction builder
   if (NETWORK === `mainnet`)
@@ -109,7 +110,7 @@ async function sendBch() {
   // output rawhex
   const hex = tx.toHex()
   console.log(`Transaction raw hex: `)
-  console.log(hex)
+  //console.log(hex)
 
   // sendRawTransaction to running BCH node
   const broadcast = await Wormhole.RawTransactions.sendRawTransaction(hex)


### PR DESCRIPTION
So all my crafty TX manipulation on the last PR produced accurate looking transaction script, but did not result in WHC tokens being delivered after several confirmation. This PR revers the burnBCH code back to known, working code. I tested it and verified that this code works with [testnet TX 6b5da2ff60855fe037e080431796e03ac9255702bdb08401fde2e6648d598e92](https://trest.bitcoin.com/v1/dataRetrieval/transaction/6b5da2ff60855fe037e080431796e03ac9255702bdb08401fde2e6648d598e92)